### PR TITLE
Remove operator warning

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ class App extends Component{
           ...this.state,
           loader:false
         })
-        if(this.state.total_count != total_count){
+        if(this.state.total_count !== total_count){
           this.setState({
             total_count: total_count
           });


### PR DESCRIPTION
This change removes the following warning when running `yarn start`

```
Compiled with warnings.

./src/App.js
  Line 48:35:  Expected '!==' and instead saw '!='  eqeqeq

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```

For more information on Javascript operators you can read this [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators)